### PR TITLE
Fix hyperparameter naming in readme, add learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Multi-layer Recurrent Neural Networks (LSTM, RNN) for character-level language m
 Based on [char-rnn-tensorflow](https://github.com/sherjilozair/char-rnn-tensorflow).
 
 **Notes**: 
-- **[Here](https://blog.paperspace.com/training-an-lstm-and-using-the-model-in-ml5-js/)** is a blog post describing how to train and use an LSTM network in ml5.
+- **[Here](https://blog.paperspace.com/training-an-lstm-and-using-the-model-in-ml5-js/)** is a blog post describing how to train and use an LSTM network in ml5.js.
 
-- **[Here](https://youtu.be/xfuVcfwtEyw)** is a video showing how to train an LSTM network using Spell and ml5.js to generate text in the style of a particular author 
+- **[Here](https://youtu.be/xfuVcfwtEyw)** is a video showing how to train an LSTM network using Spell and ml5.js to generate text in the style of a particular author.
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -80,25 +80,27 @@ Given the size of the training dataset, here are some hyperparameters that might
 
 * 2 MB: 
    - rnn_size 256 (or 128) 
-   - layers 2 
+   - num_layers 2 
    - seq_length 64 
    - batch_size 32 
-   - dropout 0.25
+   - output_keep_prob 0.75 
 * 5-8 MB: 
   - rnn_size 512 
-  - layers 2 (or 3) 
+  - num_layers 2 (or 3) 
   - seq_length 128 
   - batch_size 64 
   - dropout 0.25
 * 10-20 MB: 
   - rnn_size 1024 
-  - layers 2 (or 3) 
+  - num_layers 2 (or 3) 
   - seq_length 128 (or 256) 
   - batch_size 128 
-  - dropout 0.25
+  - output_keep_prob 0.75 
 * 25+ MB: 
   - rnn_size 2048 
-  - layers 2 (or 3) 
+  - num_layers 2 (or 3) 
   - seq_length 256 (or 128) 
   - batch_size 128 
-  - dropout 0.25
+  - output_keep_prob 0.75
+  
+Note: output_keep_prob 0.75 is equivalent to dropout probability of 0.25.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Multi-layer Recurrent Neural Networks (LSTM, RNN) for character-level language m
 
 Based on [char-rnn-tensorflow](https://github.com/sherjilozair/char-rnn-tensorflow).
 
+**Notes**: 
+- **[Here](https://blog.paperspace.com/training-an-lstm-and-using-the-model-in-ml5-js/)** is a blog post describing how to train and use an LSTM network in ml5.
+
+- **[Here](https://youtu.be/xfuVcfwtEyw)** is a video showing how to train an LSTM network using Spell and ml5.js to generate text in the style of a particular author 
+
+
 ## Requirements
 
 - Set up a python environment with tensorflow installed. [More detailed instructions here](https://ml5js.org/docs/training-setup.html). You can also follow this [video tutorial about Python virtualenv](https://youtu.be/nnhjvHYRsmM).


### PR DESCRIPTION
Hello there, 

I made some changes in the hyperparameters section to reflect the argument names the model accepts, namely:

- layers -> num_layers
- dropout -> output_keep_prob

I also changed the suggested value of the latter from 0.25 to 0.75, as I'm assuming the author suggests dropout rate of 0.25, which corresponds to output_keep_prob of 0.75 in TensorFlow's DropoutWrapper. 

Additionally, I added the learning resources Daniel lists in issue #7.

Thanks so much for your work on ml5 and tutorials, it's an absolute joy to play with. :) 

Cheers,
Raf