### PR TITLE
Change preprocess files naming to avoid cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,29 @@ That's it!
 
 Given the size of the training dataset, here are some hyperparameters that might work:
 
-* 2 MB:
-   - rnn_size 256 (or 128)
-   - num_layers 2
-   - seq_length 64
-   - batch_size 32
-   - output_keep_prob 0.75
-   (output_keep_prob: probability of keeping weights in the hidden layer)
-* 5-8 MB:
-  - rnn_size 512
-  - num_layers 2 (or 3)
-  - seq_length 128
-  - batch_size 64
+* 2 MB: 
+   - rnn_size 256 (or 128) 
+   - num_layers 2 
+   - seq_length 64 
+   - batch_size 32 
+   - output_keep_prob 0.75 
+* 5-8 MB: 
+  - rnn_size 512 
+  - num_layers 2 (or 3) 
+  - seq_length 128 
+  - batch_size 64 
+  - dropout 0.25
+* 10-20 MB: 
+  - rnn_size 1024 
+  - num_layers 2 (or 3) 
+  - seq_length 128 (or 256) 
+  - batch_size 128 
+  - output_keep_prob 0.75 
+* 25+ MB: 
+  - rnn_size 2048 
+  - num_layers 2 (or 3) 
+  - seq_length 256 (or 128) 
+  - batch_size 128 
   - output_keep_prob 0.75
-* 10-20 MB:
-  - rnn_size 1024
-  - num_layers 2 (or 3)
-  - seq_length 128 (or 256)
-  - batch_size 128
-  - output_keep_prob 0.75
-* 25+ MB:
-  - rnn_size 2048
-  - num_layers 2 (or 3)
-  - seq_length 256 (or 128)
-  - batch_size 128
-  - output_keep_prob 0.75
+  
+Note: output_keep_prob 0.75 is equivalent to dropout probability of 0.25.

--- a/README.md
+++ b/README.md
@@ -80,25 +80,26 @@ Given the size of the training dataset, here are some hyperparameters that might
 
 * 2 MB:
    - rnn_size 256 (or 128)
-   - layers 2
+   - num_layers 2
    - seq_length 64
    - batch_size 32
-   - dropout 0.25
+   - output_keep_prob 0.75
+   (output_keep_prob: probability of keeping weights in the hidden layer)
 * 5-8 MB:
   - rnn_size 512
-  - layers 2 (or 3)
+  - num_layers 2 (or 3)
   - seq_length 128
   - batch_size 64
-  - dropout 0.25
+  - output_keep_prob 0.75
 * 10-20 MB:
   - rnn_size 1024
-  - layers 2 (or 3)
+  - num_layers 2 (or 3)
   - seq_length 128 (or 256)
   - batch_size 128
-  - dropout 0.25
+  - output_keep_prob 0.75
 * 25+ MB:
   - rnn_size 2048
-  - layers 2 (or 3)
+  - num_layers 2 (or 3)
   - seq_length 256 (or 128)
   - batch_size 128
-  - dropout 0.25
+  - output_keep_prob 0.75

--- a/utils.py
+++ b/utils.py
@@ -14,7 +14,7 @@ class TextLoader():
         input_file = os.path.join(data_dir)
         input_dir = os.path.dirname(input_file)
         input_file_name = os.path.split(input_file)[-1].split('.')[0]
-        if !os.path.exists('textloader/'):
+        if not os.path.exists('textloader/'):
         	os.mkdir('textloader/')
         vocab_file = os.path.join('textloader/', input_file_name + "_vocab.pkl")
         tensor_file = os.path.join('textloader/', input_file_name + "_tensor.npy")

--- a/utils.py
+++ b/utils.py
@@ -13,14 +13,15 @@ class TextLoader():
 
         input_file = os.path.join(data_dir)
         input_dir = os.path.dirname(input_file)
-        vocab_file = os.path.join(input_dir, "vocab.pkl")
-        tensor_file = os.path.join(input_dir, "data.npy")
+        input_file_name = os.path.split(input_file)[-1].split('.')[0]
+        vocab_file = os.path.join(input_dir, input_file_name + ".pkl")
+        tensor_file = os.path.join(input_dir, input_file_name + ".npy")
 
         if not (os.path.exists(vocab_file) and os.path.exists(tensor_file)):
             print("Here we go! Reading text file...")
             self.preprocess(input_file, vocab_file, tensor_file)
         else:
-            print("Loading preprocessed files")
+            print("Loading preprocessed files...")
             self.load_preprocessed(vocab_file, tensor_file)
         self.create_batches()
         self.reset_batch_pointer()

--- a/utils.py
+++ b/utils.py
@@ -14,8 +14,9 @@ class TextLoader():
         input_file = os.path.join(data_dir)
         input_dir = os.path.dirname(input_file)
         input_file_name = os.path.split(input_file)[-1].split('.')[0]
-        vocab_file = os.path.join(input_dir, input_file_name + ".pkl")
-        tensor_file = os.path.join(input_dir, input_file_name + ".npy")
+        os.mkdir('textloader/')
+        vocab_file = os.path.join('textloader/', input_file_name + "_vocab.pkl")
+        tensor_file = os.path.join('textloader/', input_file_name + "_tensor.npy")
 
         if not (os.path.exists(vocab_file) and os.path.exists(tensor_file)):
             print("Here we go! Reading text file...")

--- a/utils.py
+++ b/utils.py
@@ -14,7 +14,8 @@ class TextLoader():
         input_file = os.path.join(data_dir)
         input_dir = os.path.dirname(input_file)
         input_file_name = os.path.split(input_file)[-1].split('.')[0]
-        os.mkdir('textloader/')
+        if !os.path.exists('textloader/'):
+        	os.mkdir('textloader/')
         vocab_file = os.path.join('textloader/', input_file_name + "_vocab.pkl")
         tensor_file = os.path.join('textloader/', input_file_name + "_tensor.npy")
 


### PR DESCRIPTION
Avoid models trained all become the same as the first one when running a continues training script for multiple models. Also adjust hyperparameter names in README to make it easier to understand.